### PR TITLE
Minor text adjustments on Scrapinghub at companies page

### DIFF
--- a/companies.html
+++ b/companies.html
@@ -21,7 +21,7 @@ permalink: companies/
 			<hr />
 			<p>
 			<span class="highlight">Scrapinghub:</span>
-			From the <a href="http://scrapinghub.com/about">co-creators of Scrapy</a>, Scrapinghub is a leading technology and professional services provider to successful web crawling and data processing solutions. </p>
+			From the <a href="http://scrapinghub.com/about">creators of Scrapy</a>, Scrapinghub is a leading technology and professional services company, providing successful web crawling and data processing solutions. </p>
 		</div>
 
 		<div class="company-box">


### PR DESCRIPTION
A minor text update on Scrapinghub's description on the companies page, according to @shane42 feedback :+1: 