### PR TITLE
adding more contrast for code snippets block

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -286,7 +286,7 @@ dl, dd, ol, ul, figure {
 			padding-bottom:7px;
 			margin-top:10px;
 			text-align:center;
-			background-color:$grey;
+			background-color:darken($grey, 18%);
 			@include border-radius($radius);
 			border-bottom:$border-bot $dark-green;
 			color:#ffed79;
@@ -402,7 +402,7 @@ dl, dd, ol, ul, figure {
 	.code-box {
 		width:588px;
 		height:305px;
-		background-color: $grey;
+		background-color: darken($grey, 18%);
 		float:right;
 		margin-top:30px;
 		@include border-radius($radius);


### PR DESCRIPTION
So, this just darkens the background of the code snippets a little bit, makes for a better contrast

## BEFORE:

![before](https://cloud.githubusercontent.com/assets/37565/7667610/f59981b4-fbe4-11e4-9840-0c6ad7347289.png)

## AFTER:

![after](https://cloud.githubusercontent.com/assets/37565/7667611/f7c515ca-fbe4-11e4-8700-cac44feaf360.png)
